### PR TITLE
Deprecate WirelessRadio, remove XBee support in server, remove XBee settings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,14 +4,11 @@
 flowchart TD
  subgraph s1["KevinbotLib Server"]
         n5["KevinbotLib<br>Direct Serial"]
-        n9["XBee Interface"]
   end
     n3["MQTT API Mode"] <--> n4["MQTT Broker"]
     n4 <--> s1
     n5 --> n6["Kevinbot<br>Hardware"]
     n2["Direct Serial"] --> n6
-    n9 <--> n5
-    n9 --> n4
     n10["OR"] --> n11["Direct Serial Mode<br>"] & n12["MQTT Mode"]
     n1["KevinbotLib"] --> n10
     n11 --> n2
@@ -25,9 +22,6 @@ flowchart TD
     n1@{ shape: rect}
     n12@{ shape: text}
 ```
-
-!!! note "XBee"
-    KevinbotLib does not support XBee communication at this moment
 
 
 ## Serial vs. MQTT

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,6 @@ KevinbotLib is a robot control system for Kevinbot v3 and the [Kevinbot Core](ht
 * **Multiple Control Interfaces**
     * Direct Serial mode
     * MQTT networked mode (with KevinbotLib Server)
-    * XBee communication (planned)
 
 
 * **Comprehensive Subsystem Control**

--- a/src/kevinbotlib/__init__.py
+++ b/src/kevinbotlib/__init__.py
@@ -18,7 +18,6 @@ from kevinbotlib.states import (
     EyeSkin,
     EyeMotion,
 )
-from kevinbotlib.xbee import WirelessRadio
 
 __all__ = [
     "SerialKevinbot",
@@ -27,7 +26,6 @@ __all__ = [
     "Servo",
     "Servos",
     "Lighting",
-    "WirelessRadio",
     "KevinbotState",
     "DrivebaseState",
     "SerialEyes",

--- a/src/kevinbotlib/cli/server.py
+++ b/src/kevinbotlib/cli/server.py
@@ -22,7 +22,7 @@ def server(
     verbose: bool,
     trace: bool,
 ):
-    """Start the Kevinbot MQTT and XBee inferface"""
+    """Start the Kevinbot MQTT inferface"""
 
     if trace:
         logger.remove()

--- a/src/kevinbotlib/config.py
+++ b/src/kevinbotlib/config.py
@@ -119,52 +119,6 @@ class _Core:
         }
 
 
-class _XBee:
-    def __init__(self, data: dict[str, Any], config: "KevinbotConfig"):
-        self._config = config
-        self._data = data
-
-    @property
-    def port(self) -> str:
-        return self._data.get("port", "/dev/ttyAMA0")
-
-    @port.setter
-    def port(self, value: str):
-        self._data["port"] = value
-        self._config.save()
-
-    @property
-    def baud(self) -> int:
-        return self._data.get("baud", 921600)
-
-    @baud.setter
-    def baud(self, value: int):
-        self._data["baud"] = value
-        self._config.save()
-
-    @property
-    def timeout(self) -> float:
-        return self._data.get("timeout", 5.0)
-
-    @timeout.setter
-    def timeout(self, value: int):
-        self._data["timeout"] = value
-        self._config.save()
-
-    @property
-    def api(self) -> int:
-        return self._data.get("api", 2)
-
-    @api.setter
-    def api(self, value: int):
-        self._data["api"] = value
-        self._config.save()
-
-    @property
-    def data(self):
-        return {"port": self.port, "baud": self.baud, "timeout": self.timeout, "api": self.api}
-
-
 class _Server:
     def __init__(self, data: dict[str, Any], config: "KevinbotConfig"):
         self._config = config
@@ -180,17 +134,8 @@ class _Server:
         self._config.save()
 
     @property
-    def enable_xbee(self) -> bool:
-        return self._data.get("enable_xbee", True)
-
-    @enable_xbee.setter
-    def enable_xbee(self, value: bool):
-        self._data["enable_xbee"] = value
-        self._config.save()
-
-    @property
     def data(self):
-        return {"root_topic": self.root_topic, "enable_xbee": self.enable_xbee}
+        return {"root_topic": self.root_topic}
 
 
 class KevinbotConfig:
@@ -210,7 +155,6 @@ class KevinbotConfig:
 
         self.mqtt: _MQTT = _MQTT({}, self)
         self.core: _Core = _Core({}, self)
-        self.xbee: _XBee = _XBee({}, self)
         self.server: _Server = _Server({}, self)
 
         self.load()
@@ -246,7 +190,6 @@ class KevinbotConfig:
 
         self.mqtt = _MQTT(self.config.get("mqtt", {}), self)
         self.core = _Core(self.config.get("core", {}), self)
-        self.xbee = _XBee(self.config.get("xbee", {}), self)
         self.server = _Server(self.config.get("server", {}), self)
 
     def save(self) -> None:
@@ -268,7 +211,6 @@ class KevinbotConfig:
         return {
             "mqtt": self.mqtt.data,
             "core": self.core.data,
-            "xbee": self.xbee.data,
             "server": self.server.data,
         }
 

--- a/src/kevinbotlib/server.py
+++ b/src/kevinbotlib/server.py
@@ -4,7 +4,7 @@
 
 """
 KevinbotLib Robot Server
-Allow accessing KevinbotLib APIs over MQTT and XBee API Mode
+Allow accessing KevinbotLib APIs over MQTT
 """
 
 import atexit

--- a/src/kevinbotlib/server.py
+++ b/src/kevinbotlib/server.py
@@ -20,7 +20,6 @@ from paho.mqtt.client import CallbackAPIVersion, Client, MQTTMessage  # type: ig
 from kevinbotlib.config import ConfigLocation, KevinbotConfig
 from kevinbotlib.core import Drivebase, SerialKevinbot, Servos
 from kevinbotlib.states import KevinbotServerState
-from kevinbotlib.xbee import WirelessRadio
 
 
 class KevinbotServer:
@@ -28,11 +27,10 @@ class KevinbotServer:
 
     
     def __init__(
-        self, config: KevinbotConfig, robot: SerialKevinbot, radio: WirelessRadio | None, root_topic: str | None
+        self, config: KevinbotConfig, robot: SerialKevinbot, root_topic: str | None
     ) -> None:
         self.config = config
         self.robot = robot
-        self.radio = radio
         self.root: str = root_topic if root_topic else self.config.server.root_topic
 
         self.state: KevinbotServerState = KevinbotServerState()
@@ -41,9 +39,6 @@ class KevinbotServer:
         self.robot.request_disable()
         self.drive = Drivebase(robot)
         self.servos = Servos(robot)
-
-        if self.radio:
-            self.radio.callback = self.radio_callback
 
         logger.info(f"Connecting to MQTT borker at: mqtt://{self.config.mqtt.host}:{self.config.mqtt.port}")
         logger.info(f"Using MQTT root topic: {self.root}")
@@ -220,8 +215,6 @@ class KevinbotServer:
         logger.info("Exiting...")
         self.client.disconnect()
         self.robot.disconnect()
-        if self.radio:
-            self.radio.disconnect()
 
 
 def bringup(
@@ -239,11 +232,4 @@ def bringup(
     logger.info(f"New core connection: {config.core.port}@{config.core.baud}")
     logger.debug(f"Robot status is: {robot.get_state()}")
 
-    if config.server.enable_xbee:
-        radio = WirelessRadio(robot, config.xbee.port, config.xbee.baud, config.xbee.api, config.xbee.timeout)
-        logger.info(f"Xbee connection: {config.xbee.port}@{config.xbee.baud}")
-    else:
-        logger.info(f"Xbee connection: DISABLED")
-        radio = None
-
-    KevinbotServer(config, robot, radio, root_topic)
+    KevinbotServer(config, robot, root_topic)

--- a/src/kevinbotlib/xbee.py
+++ b/src/kevinbotlib/xbee.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+from typing_extensions import deprecated
 
 import xbee
 from loguru import logger
@@ -10,6 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+@deprecated("XBee radio support is deprecated. Please use WiFi or use a custom implementation. It will be removed in a future version")
 class WirelessRadio(BaseKevinbotSubsystem):
     def __init__(self, robot: SerialKevinbot, port: str, baud: int, api: int, timeout: float) -> None:
         """Initialize Kevinbot Wireless Radio (XBee)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,26 +113,6 @@ def test_core(tmp_path: Path):
     assert config.core.handshake_timeout == 12
 
 
-def test_xbee(tmp_path: Path):
-    config = KevinbotConfig(ConfigLocation.MANUAL, tmp_path.joinpath("config.yaml"))
-    assert config.xbee.baud == 921600
-    assert config.xbee.port == "/dev/ttyAMA0"
-    assert config.xbee.api == 2
-    assert config.xbee.timeout == 5
-
-    config.xbee.baud = 921600
-    assert config.xbee.baud == 921600
-
-    config.xbee.port = "/dev/ttyAMA2"
-    assert config.xbee.port == "/dev/ttyAMA2"
-
-    config.xbee.api = 1
-    assert config.xbee.api == 1
-
-    config.xbee.timeout = 10
-    assert config.xbee.timeout == 10
-
-
 def test_server(tmp_path: Path):
     config = KevinbotConfig(ConfigLocation.MANUAL, tmp_path.joinpath("config.yaml"))
     assert config.server.root_topic == "kevinbot"


### PR DESCRIPTION
These changes are part of the removal of the XBee subsystem.
This fully removes XBee radio support in the server, configs, and docs
The kevinbotlib.xbee.WirelessRadio class is now deprecated and will be removed in the future.